### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/pget/down.py
+++ b/pget/down.py
@@ -138,7 +138,7 @@ class Downloader(object):
 
     def wait_for_finish(self):
         if self.__async:
-            while self.thread.isAlive():
+            while self.thread.is_alive():
                 continue
             self.thread.join()
         else:


### PR DESCRIPTION
Fixes https://github.com/halilozercan/pget/issues/11