### PR TITLE
Added parameter option

### DIFF
--- a/pget/bin.py
+++ b/pget/bin.py
@@ -5,8 +5,8 @@ import signal
 import sys
 
 from . import down
-from .log import setup_logging
 from .down import Downloader
+from .log import setup_logging
 
 first_summary_flag = False
 logger = logging.getLogger(__name__)
@@ -84,9 +84,11 @@ def run(argv):
                         const=True, help='High speed connection flag', action='store_const')
     parser.add_argument('-H', '--header', dest='headers', metavar='HeaderKey: HeaderValue',
                         help='Add a HTTP Header for download connection', action='append')
+    parser.add_argument('-P', '--params', dest='params', metavar='ParamKey: ParamValue',
+                        help='Add Parameters for download connection', action='append')
 
     args = parser.parse_args(argv[1:])
-    downloader = Downloader(args.url, args.filename, args.chunks, args.high_speed, args.headers)
+    downloader = Downloader(args.url, args.filename, args.chunks, args.high_speed, args.headers, args.params)
 
     downloader.subscribe(download_callback, 256)
 

--- a/pget/chunk.py
+++ b/pget/chunk.py
@@ -15,7 +15,7 @@ class Chunk(object):
     STOPPED = 4
 
     def __init__(self, downloader, url, file, start_byte=-1, end_byte=-1, number=-1,
-                 high_speed=False, headers=None):
+                 high_speed=False, headers=None, params=None):
         self.url = url
         self.start_byte = int(start_byte)
         self.end_byte = int(end_byte)
@@ -26,6 +26,9 @@ class Chunk(object):
         if headers is None:
             headers = {}
         self.headers = headers
+        if params is None:
+            params = {}
+        self.params = params
 
         self.__state = Chunk.INIT
 
@@ -60,12 +63,12 @@ class Chunk(object):
         self.__state = Chunk.DOWNLOADING
         if r is None:
             if self.start_byte == -1 and self.end_byte == -1:
-                r = requests.get(self.url, stream=True, headers=self.headers)
+                r = requests.get(self.url, stream=True, headers=self.headers, params=self.params)
             else:
                 self.headers['Range'] = "bytes=" + str(self.start_byte) + "-" + str(self.end_byte)
                 if 'range' in self.headers:
                     del self.headers['range']
-                r = requests.get(self.url, stream=True, headers=self.headers)
+                r = requests.get(self.url, stream=True, headers=self.headers, params=self.params)
                 self.total_length = int(r.headers.get("content-length"))
 
         break_flag = False

--- a/pget/down.py
+++ b/pget/down.py
@@ -28,7 +28,7 @@ class Downloader(object):
     FINISHED = 4
     STOPPED = 5
 
-    def __init__(self, url, file_name, chunk_count, high_speed=False, headers=None):
+    def __init__(self, url, file_name, chunk_count, high_speed=False, headers=None, params=None):
         self.url = url
         self.file_name = file_name
         self.chunk_count = chunk_count
@@ -40,6 +40,13 @@ class Downloader(object):
             key = header.split(':')[0].strip()
             value = header.split(':')[1].strip()
             self.headers[key] = value
+        if params is None:
+            params = []
+        self.params = {}
+        for param in params:
+            key = param.split(':')[0].strip()
+            value = param.split(':')[1].strip()
+            self.params[key] = value
 
         self.total_length = 0
         self.total_downloaded = 0
@@ -142,7 +149,7 @@ class Downloader(object):
     def run(self):
         self.__state = Downloader.DOWNLOADING
 
-        r = requests.get(self.url, stream=True, headers=self.headers)
+        r = requests.get(self.url, stream=True, headers=self.headers, params=self.params)
         if r.status_code != 200:
             raise RuntimeError('Could not connect to given URL')
         try:
@@ -157,7 +164,7 @@ class Downloader(object):
 
         if self.chunk_count == 0:
             chunk_file = tempfile.TemporaryFile()
-            new_chunk = Chunk(self, self.url, file=chunk_file, high_speed=self.high_speed, headers=self.headers)
+            new_chunk = Chunk(self, self.url, file=chunk_file, high_speed=self.high_speed, headers=self.headers, params=self.params)
             self.__chunks.append(new_chunk)
             new_chunk.start()
         else:
@@ -173,7 +180,8 @@ class Downloader(object):
                         end_byte=((chunk_number + 1) * chunk_size) - 1,
                         number=chunk_number,
                         high_speed=self.high_speed,
-                        headers=self.headers)
+                        headers=self.headers,
+                        params=self.params)
                 else:
                     new_chunk = Chunk(
                         self, self.url, chunk_file,
@@ -181,7 +189,8 @@ class Downloader(object):
                         end_byte=self.total_length - 1,
                         number=chunk_number,
                         high_speed=self.high_speed,
-                        headers=self.headers)
+                        headers=self.headers,
+                        params=self.params)
 
                 self.__chunks.append(new_chunk)
                 new_chunk.start()

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 from distutils.core import setup
+
 from setuptools import find_packages
 
 setup(
     name='PGet',
-    version='0.5.1',
+    version='0.5.2',
     description='A tool and library to save large files by creating multiple connections.',
     author='Halil Ozercan',
     author_email='halilozercan@gmail.com',
     url='https://github.com/halilozercan/pget',
-    download_url='https://github.com/halilozercan/pget/tarball/0.5.1',
+    download_url='https://github.com/halilozercan/pget/tarball/0.5.2',
     entry_points={
         'console_scripts': [
             'pget = pget.bin:main',


### PR DESCRIPTION
Added `params` option for python requests library.
The format is modeled after the `header` option.

```python
from pget.down import Downloader

api_url = 'https://website.com'
db_file = "streams.db"
headers = [
    "User-Agent:  Dalvik/2.1.0 (Linux; U; Android 11; J8170 Build/55.2.A.4.154)",
    "Accept-Encoding: gzip, deflate"
]
params = [
    "action: get_data_table",
    "stream_id: 123456"
]
downloader = Downloader(url=api_url, file_name=db_file, chunk_count=8, headers=headers, params=params, high_speed=True)
downloader.start()
downloader.subscribe(callback, callback_threshold)
downloader.wait_for_finish()
```    
